### PR TITLE
feat: re-parse after running `--fix`

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -153,22 +153,19 @@ jobs:
         working-directory: ${{ matrix.path }}
         if: ${{ matrix.path != 'DefinitelyTyped' }}
         run: |
-          oxlint_args="\
-            --jsdoc-plugin \
-            --jest-plugin \
-            --vitest-plugin \
-            --jsx-a11y-plugin \
-            --nextjs-plugin \
-            --react-perf-plugin \
-            -A all \
-          "
+          oxlint_args="--jsdoc-plugin --jest-plugin --vitest-plugin --jsx-a11y-plugin --nextjs-plugin --react-perf-plugin -A all"
 
           has_oxlintignore=$(ls | grep .oxlintignore | wc -l | xargs)
           if [[ $has_oxlintignore -gt 0 ]]; then
+            echo ".oxlintignore exists"
             oxlint_args="$oxlint_args --ignore-path .oxlintignore"
+          else
+            echo ".oxlintignore does not exist"
           fi
 
           ./oxlint $oxlint_args
+        env:
+          RUST_BACKTRACE: '1'
 
   comment:
     needs: test

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -151,17 +151,24 @@ jobs:
       # a parse error or a panic.
       - name: Re-Parse After `--fix`
         working-directory: ${{ matrix.path }}
+        if: ${{ matrix.path != 'DefinitelyTyped' }}
         run: |
-          ./oxlint \
-            --fix \
+          oxlint_args="\
             --jsdoc-plugin \
             --jest-plugin \
             --vitest-plugin \
             --jsx-a11y-plugin \
             --nextjs-plugin \
             --react-perf-plugin \
-            -W all \
-            --silent
+            -A all \
+          "
+
+          has_oxlintignore=$(ls | grep .oxlintignore | wc -l | xargs)
+          if [[ $has_oxlintignore -gt 0 ]]; then
+            oxlint_args="$oxlint_args --ignore-path .oxlintignore"
+          fi
+
+          ./oxlint $oxlint_args
 
   comment:
     needs: test

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -119,10 +119,21 @@ jobs:
 
       - name: Check Panic
         working-directory: ${{ matrix.path }}
+        # NOTE (@DonIsaac): should we enable import-plugin?
+        # NOTE (@DonIsaac): should we test nursery rules too?
         run: |
           set +e # disable exit on run
 
-          ./oxlint --fix --jest-plugin --jsdoc-plugin --jsx-a11y-plugin --nextjs-plugin --react-perf-plugin -D all --silent
+          ./oxlint \
+            --fix \
+            --jsdoc-plugin \
+            --jest-plugin \
+            --vitest-plugin \
+            --jsx-a11y-plugin \
+            --nextjs-plugin \
+            --react-perf-plugin \
+            -D all \
+            --silent
 
           EXIT_CODE=$?
 
@@ -134,6 +145,23 @@ jobs:
 
           echo "exitcode=0" >> $GITHUB_OUTPUT
           exit 0
+
+      # Check for invalid syntax after lint rule violations have been fixed.
+      # All lint rules are set to `warning` here, so an exit code > 0 is either
+      # a parse error or a panic.
+      - name: Re-Parse After `--fix`
+        working-directory: ${{ matrix.path }}
+        run: |
+          ./oxlint \
+            --fix \
+            --jsdoc-plugin \
+            --jest-plugin \
+            --vitest-plugin \
+            --jsx-a11y-plugin \
+            --nextjs-plugin \
+            --react-perf-plugin \
+            -W all \
+            --silent
 
   comment:
     needs: test

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -153,17 +153,17 @@ jobs:
         working-directory: ${{ matrix.path }}
         if: ${{ matrix.path != 'DefinitelyTyped' }}
         run: |
-          oxlint_args="--jsdoc-plugin --jest-plugin --vitest-plugin --jsx-a11y-plugin --nextjs-plugin --react-perf-plugin -A all"
+          OXLINT_ARGS="--jsdoc-plugin --jest-plugin --vitest-plugin --jsx-a11y-plugin --nextjs-plugin --react-perf-plugin -A all"
 
-          has_oxlintignore=$(ls | grep .oxlintignore | wc -l | xargs)
-          if [[ $has_oxlintignore -gt 0 ]]; then
-            echo ".oxlintignore exists"
-            oxlint_args="$oxlint_args --ignore-path .oxlintignore"
+          HAS_OXLINTIGNORE=$(ls | grep .oxlintignore | wc -l | xargs)
+          if [ $HAS_OXLINTIGNORE -gt 0 ]; then
+              echo ".oxlintignore exists"
+              OXLINT_ARGS="$OXLINT_ARGS --ignore-path .oxlintignore"
           else
-            echo ".oxlintignore does not exist"
+              echo ".oxlintignore does not exist"
           fi
 
-          ./oxlint $oxlint_args
+          ./oxlint $OXLINT_ARGS
         env:
           RUST_BACKTRACE: '1'
 


### PR DESCRIPTION
Related to, but does not fully address, #19.

> NOTE: this PR also enables the vitest plugin

Adds a step to the test stage that re-runs oxlint after it was previously run with `--fix`. This should help us catch syntax errors created by buggy fixes.

We should also consider running `typecheck` scripts for repositories that have them.