### PR TITLE
feat: add reset command

### DIFF
--- a/bin/clone.js
+++ b/bin/clone.js
@@ -1,10 +1,20 @@
 #!/usr/bin/env node
 
 const exec = require("child_process").exec;
-
 const matrix = require("../matrix.json");
 
-for (const item of matrix) {
+/**
+ * @typedef {Object} MatrixItem
+ * @property {string} repository
+ * @property {string} path
+ * @property {string} ref
+ * @property {string} command
+ */
+
+/**
+ * @param {MatrixItem} item
+ */
+function cloneRepo(item) {
   const command = `git clone --depth=1 --filter blob:limit=200k --no-tags -b ${item.ref} git@github.com:${item.repository}.git repos/${item.path}`;
 
   console.log(`Running ${command}`);
@@ -16,3 +26,11 @@ for (const item of matrix) {
     console.log(`Cloned ${item.repository}`);
   });
 }
+
+if (require.main === module) {
+  for (const item of matrix) {
+    cloneRepo(item);
+  }
+}
+
+module.exports = { cloneRepo }

--- a/bin/reset.js
+++ b/bin/reset.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * @file reset.js
+ * @summary Forcibly reset all repositories to the latest commit on their
+ * default branch. All local changes will be lost.
+ */
+
+const { cloneRepo } = require("./clone");
+const matrix = require("../matrix.json");
+const fs = require("fs");
+const cp = require("child_process");
+
+/**
+ * @param {import("./clone").MatrixItem} item
+ */
+function syncAndResetRepo(item) {
+    const cmd = [
+        `cd repos/${item.path}`,
+        `git reset --hard`,
+        `git checkout ${item.ref}`,
+        `git pull`,
+    ].join(" && ");
+
+    console.log(`Running ${cmd}`);
+    cp.execSync(cmd, { stdio: "inherit" });
+}
+
+function reset() {
+    // await fs.promises.mkdir("repos", { recursive: true });
+    fs.mkdirSync("repos", { recursive: true });
+
+    let failed = false;
+    for (const item of matrix) {
+        if (!fs.existsSync(`repos/${item.path}`)) {
+            cloneRepo(item);
+        } else {
+            try {
+                syncAndResetRepo(item);
+            } catch (e) {
+                console.error(e);
+                failed = true;
+            }
+        }
+    }
+
+    if (failed) {
+        process.exit(1);
+    }
+}
+
+if (require.main === module) {
+    reset();
+}
+

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "test": "RUST_BACKTRACE=1 node bin/test.js",
         "test:default": "RUST_BACKTRACE=1 node bin/test.js $(which oxlint)",
         "update": "node bin/update.js",
+        "reset": "node bin/reset.js",
         "lint": "npx oxlint@latest ."
     }
 }


### PR DESCRIPTION
Add a script that, for each repo, clones it if not done already, otherwise it will

1. Reset to HEAD, discarding any local changes (`git reset --hard`)
2. Check out the default branch
3. Fetch upstream changes (`git pull`)

I find myself making PRs within these repos, and this is a good way to reset to the "default" state.