### PR TITLE
ci: add security analysis workflow

### DIFF
--- a/.github/workflows/oxfmt-ci.yml
+++ b/.github/workflows/oxfmt-ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: oxc-project/setup-node@4c26e7cb3605b6bdef5450dacd02c434b10fd8ba # v1.2.0
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
 
       - run: pnpm install
 
@@ -140,7 +140,7 @@ jobs:
         with:
           node-version: 24
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
           version: 10
 
@@ -210,10 +210,12 @@ jobs:
       - name: Check diff (main branch vs oxfmt@latest)
         if: ${{ !cancelled() }}
         working-directory: ${{ matrix.path }}
+        env:
+          OXFMT_REF: ${{ inputs.ref || 'main' }}
         run: |
           git diff > /tmp/main.diff
           if ! diff -q /tmp/latest.diff /tmp/main.diff > /dev/null 2>&1; then
-            echo "$(oxfmt --version) (${{ inputs.ref || 'main' }} branch) differs from oxfmt@latest:"
+            echo "$(oxfmt --version) ($OXFMT_REF branch) differs from oxfmt@latest:"
             diff /tmp/latest.diff /tmp/main.diff || true
             exit 1
           fi

--- a/.github/workflows/oxlint-ci.yml
+++ b/.github/workflows/oxlint-ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: oxc-project/setup-node@4c26e7cb3605b6bdef5450dacd02c434b10fd8ba # v1.2.0
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
 
       - run: pnpm install
         working-directory: ./apps/oxlint
@@ -140,7 +140,7 @@ jobs:
         with:
           node-version: 24
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6
+      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
           version: 10
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,12 +5,12 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
 
 permissions: {}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security Analysis
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  security:
+    name: Security Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oxc-project/security-action@fbbd523b1e765ceb174cb819b92c453bb1da265e # v1.0.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
-    paths:
-      - ".github/workflows/**"
   push:
     branches:
       - main
@@ -21,6 +19,6 @@ concurrency:
 jobs:
   security:
     name: Security Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: oxc-project/security-action@fbbd523b1e765ceb174cb819b92c453bb1da265e # v1.0.0


### PR DESCRIPTION
## Summary
- add the canonical Security Analysis workflow using `oxc-project/security-action`
- replace legacy zizmor workflow files where present

## Testing
- Not run; workflow-only change.
