### PR TITLE
fix(oxlint): ignore vscode copilot fixture files

### DIFF
--- a/oxlint-matrix.json
+++ b/oxlint-matrix.json
@@ -27,7 +27,7 @@
     "repository": "microsoft/vscode",
     "ref": "main",
     "path": "vscode",
-    "command": "oxlint -W all --ignore-pattern '**/fixtures' --ignore-pattern 'test-*.ts' --silent"
+    "command": "oxlint -W all --ignore-pattern '**/fixtures' --ignore-pattern 'test-*.ts' --ignore-pattern 'extensions/copilot/test/scenarios/**' --silent"
   },
   {
     "repository": "calcom/cal.com",


### PR DESCRIPTION
these files deliberatly contain invalid JS, which causes parse to fail, reporting hard errors.

Ignore these files, to get vscode passing.