### PR TITLE
fix: run `pnpm i` before running rolldown fo vite+ is installed

### DIFF
--- a/oxlint-matrix.json
+++ b/oxlint-matrix.json
@@ -3,7 +3,7 @@
     "repository": "rolldown/rolldown",
     "ref": "main",
     "path": "rolldown",
-    "command": "VP_VERSION=1 oxlint --deny-warnings --ignore-path=.oxlintignore --import-plugin --jsdoc-plugin"
+    "command": "pnpm i --frozen-lockfile && VP_VERSION=1 oxlint --deny-warnings --ignore-path=.oxlintignore --import-plugin --jsdoc-plugin"
   },
   {
     "repository": "napi-rs/napi-rs",


### PR DESCRIPTION
else we're getting a cannot resolve `vite-plus` module error when running this job