### PR TITLE
chore: remove rolldown from oxlint matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ See [./oxlint-matrix.json](./oxlint-matrix.json).
 
 Notable repositories:
 
-* [rolldown/rolldown](https://github.com/rolldown-rs/rolldown)
 * [napi-rs/napi-rs](https://github.com/napi-rs/napi-rs)
 * [toeverything/affine](https://github.com/toeverything/affine)
 * [preactjs/preact](https://github.com/preactjs/preact)

--- a/oxlint-matrix.json
+++ b/oxlint-matrix.json
@@ -1,12 +1,5 @@
 [
   {
-    "repository": "rolldown/rolldown",
-    "ref": "main",
-    "path": "rolldown",
-    "setup": "pnpm i --frozen-lockfile",
-    "command": "VP_VERSION=1 oxlint -c vite.config.ts --deny-warnings --ignore-path=.oxlintignore --import-plugin --jsdoc-plugin"
-  },
-  {
     "repository": "cloudflare/kumo",
     "ref": "main",
     "path": "kumo",


### PR DESCRIPTION
Rolldown has been failing for a while (since using --type-check) since it needs napi to be built before running oxlint - this makes our ecosystem CI wayy too complext, so remove rolldown from the list.